### PR TITLE
Formatting cleanup & CI dependency bumps

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,7 +35,7 @@ jobs:
           - x64
     steps:
       - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
+      - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
@@ -69,7 +69,7 @@ jobs:
         run: julia --project=docs/ docs/make.jl
       - name: Make comment with preview link
         if: ${{ github.event_name == 'pull_request' && github.event.action == 'opened'}}
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             github.rest.issues.createComment({

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GMime"
 uuid = "158299e7-fc4f-4c3e-9fda-ad8bb0e07f1e"
-version = "1.2.1"
+version = "1.2.2"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/Parser.jl
+++ b/src/Parser.jl
@@ -184,7 +184,7 @@ function extract_date(msg::Ptr{GMimeMessage})
     end
 end
 
-function extract_received_at(hs::HeaderList; options=g_mime_format_options_get_default())
+function extract_received_at(hs::HeaderList; options = g_mime_format_options_get_default())
     received_dts = DateTime[]
     for header in hs
         header.name != "Received" && continue


### PR DESCRIPTION
## Summary
- Bump patch version 1.2.1 → 1.2.2
- Fix kwarg spacing in `Parser.jl` (`options=` → `options = `)
- Bump julia-actions/setup-julia from 2 to 3
- Bump actions/github-script from 8 to 9

Closes #16, closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)